### PR TITLE
set canonical_engine for redshift uris to 'redshift'

### DIFF
--- a/lib/URI/redshift.pm
+++ b/lib/URI/redshift.pm
@@ -2,4 +2,6 @@ package URI::redshift;
 use base 'URI::pg';
 our $VERSION = '0.18';
 
+sub canonical_engine { 'redshift' }
+
 1;

--- a/t/engines.t
+++ b/t/engines.t
@@ -15,7 +15,7 @@ for my $spec (
     [ pg         => 5432,  'pg'        ],
     [ pgxc       => 5432,  'pg'        ],
     [ postgresxc => 5432,  'pg'        ],
-    [ redshift   => 5432,  'pg'        ],
+    [ redshift   => 5432,  'redshift'  ],
     [ mysql      => 3306,  'mysql'     ],
     [ mariadb    => 3306,  'mysql'     ],
     [ maria      => 3306,  'mysql'     ],


### PR DESCRIPTION
@theory - sorry, I screwed up on PR #12, I needed to set 'canonical_engine' for redshift uris.  That is presupposing that you agree that the 'engine' should be redshift with a driver of postgres.  
