### PR TITLE
Add support for ClickHouse URI

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension URI::db.
 
 0.23
+     - Added URI::clickhouse. Thanks to Ilia Rassadin for the PR (#18).
 
 0.22 2024-04-05T01:38:17Z
      - Changed Oracle database DBI parameter generation as follows:

--- a/lib/URI/clickhouse.pm
+++ b/lib/URI/clickhouse.pm
@@ -1,0 +1,7 @@
+package URI::clickhouse;
+use base 'URI::_odbc';
+our $VERSION = '0.20';
+
+sub default_port { 8123 }
+
+1;

--- a/t/dbi.t
+++ b/t/dbi.t
@@ -501,6 +501,34 @@ for my $spec (
         dsn => 'dbi:Pg:host=foo;port=123;dbname=try;foo=1;foo=2;lol=yes',
         dbi => [ [host => 'foo'], [port => 123], [dbname => 'try'] ],
         qry => [ foo => 1, foo => 2, lol => 'yes' ],
+        uri => 'db:clickhouse:',
+        dsn => 'dbi:ODBC:',
+        dbi => [ [DSN => undef] ],
+        qry => [],
+    },
+    {
+        uri => 'db:clickhouse:dbadmin',
+        dsn => 'dbi:ODBC:DSN=dbadmin',
+        dbi => [ [DSN => 'dbadmin'] ],
+        qry => [],
+    },
+    {
+        uri => 'db:clickhouse://yow',
+        dsn => 'dbi:ODBC:Server=yow;Port=8123',
+        dbi => [ [Server => 'yow'], [Port => 8123], [Database => undef] ],
+        qry => [],
+    },
+    {
+        uri => 'db:clickhouse://yow:33',
+        dsn => 'dbi:ODBC:Server=yow;Port=33',
+        dbi => [ [Server => 'yow'], [Port => 33], [Database => undef] ],
+        qry => [],
+    },
+    {
+        uri => 'db:clickhouse://foo:123/try?foo=1&foo=2&lol=yes&Driver=ClickHouse',
+        dsn => 'dbi:ODBC:Server=foo;Port=123;Database=try;foo=1;foo=2;lol=yes;Driver=ClickHouse',
+        dbi => [ [Server => 'foo'], [Port => 123], [Database => 'try'] ],
+        qry => [ foo => 1, foo => 2, lol => 'yes', Driver => 'ClickHouse' ],
     },
 ) {
     my $uri = $spec->{uri};

--- a/t/engines.t
+++ b/t/engines.t
@@ -53,6 +53,7 @@ for my $spec (
     [ cockroachdb => 26257, 'cockroach' ],
     [ yugabyte    => 5433,  'pg'        ],
     [ yugabytedb  => 5433,  'pg'        ],
+    [ clickhouse => 8123,  'clickhouse' ],
 ) {
     my ($engine, $port, $canon) = @{ $spec };
     my $prefix = "db:$engine";


### PR DESCRIPTION
To support connections to [ClickHouse Databases](https://clickhouse.yandex/docs/en/), which supports [ODBC](https://github.com/yandex/clickhouse-odbc).