### PR TITLE
Use EZCONNECT for Oracle DBI params

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension URI::db.
 
 0.21
+     - Changed Oracle database DBI parameter name from `sid` to
+       `service_name`. Thanks to @vectro for the report (#22).
 
 0.20  2022-06-20T17:48:44Z
       - Added URI::cockroach and URI::yugabyte.

--- a/lib/URI/oracle.pm
+++ b/lib/URI/oracle.pm
@@ -10,15 +10,8 @@ sub _dbi_param_map {
     return (
         [ host => scalar $self->host   ],
         [ port => scalar $self->_port  ],
-        [ sid  => scalar $self->dbname ],
+        [ service_name => scalar $self->dbname ],
     );
-}
-
-sub dbi_dsn {
-    my $self = shift;
-    my $params = $self->_dsn_params;
-    $params =~ s/sid=// unless $self->host || $self->_port;
-    return join ':' => 'dbi', $self->dbi_driver, $params
 }
 
 1;

--- a/t/dbi.t
+++ b/t/dbi.t
@@ -206,14 +206,32 @@ for my $spec (
     },
     {
         uri => 'db:oracle://localhost:33/foo',
-        dsn => 'dbi:Oracle:host=localhost;port=33;sid=foo',
-        dbi => [ [host => 'localhost'], [port => 33], [sid => 'foo'] ],
+        dsn => 'dbi:Oracle:host=localhost;port=33;service_name=foo',
+        dbi => [ [host => 'localhost'], [port => 33], [service_name => 'foo'] ],
+        qry => [],
+    },
+    {
+        uri => 'db:oracle://localhost/foo',
+        dsn => 'dbi:Oracle:host=localhost;service_name=foo',
+        dbi => [ [host => 'localhost'], [port => undef], [service_name => 'foo'] ],
+        qry => [],
+    },
+    {
+        uri => 'db:oracle://:42/foo',
+        dsn => 'dbi:Oracle:port=42;service_name=foo',
+        dbi => [ [host => ''], [port => 42], [service_name => 'foo'] ],
         qry => [],
     },
     {
         uri => 'db:oracle:foo',
-        dsn => 'dbi:Oracle:foo',
-        dbi => [ [host => undef], [port => undef], [sid => 'foo'] ],
+        dsn => 'dbi:Oracle:service_name=foo',
+        dbi => [ [host => undef], [port => undef], [service_name => 'foo'] ],
+        qry => [],
+    },
+    {
+        uri => 'db:oracle:///foo',
+        dsn => 'dbi:Oracle:service_name=foo',
+        dbi => [ [host => ''], [port => undef], [service_name => 'foo'] ],
         qry => [],
     },
     {


### PR DESCRIPTION
The goal is to get away from hard-coding support for a SID, since we can't actually tell whether the database name part of the URL should be a SID or a service name. The hope is that by just returning an EZCONNECT URL, instead, the DBI or Oracle client library it uses can make the appropriate determination. Resolves #22.