### PR TITLE
Use DBD::MariaDB instead of DBD::mysql

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for Perl extension URI::db.
 
 0.23
+    - Changed the MySQL (and MariaDB) URI `dbi_dsn()` method to use
+      DBD::MariaDB instead of DBD::mysql, because it better supports older
+      MySQL client libraries and improves Unicode support.
 
 0.22 2024-04-05T01:38:17Z
      - Changed Oracle database DBI parameter generation as follows:

--- a/lib/URI/db.pm
+++ b/lib/URI/db.pm
@@ -282,7 +282,7 @@ DBI DSN. Some examples:
   | URI                                  | DSN                                              |
   |--------------------------------------+--------------------------------------------------|
   | db:pg:try                            | dbi:Pg:dbname=try                                |
-  | db:mysql://localhost:33/foo          | dbi:mysql:host=localhost;port=33;database=foo    |
+  | db:mysql://localhost:33/foo          | dbi:MariaDB:host=localhost;port=33;database=foo    |
   | db:db2://localhost:33/foo            | dbi:DB2:HOSTNAME=localhost;PORT=33;DATABASE=foo  |
   | db:vertica:dbadmin                   | dbi:ODBC:DSN=dbadmin                             |
   | db:mssql://foo.com/pubs?Driver=MSSQL | dbi:ODBC:Host=foo.com;Database=pubs;Driver=MSSQL |

--- a/lib/URI/mysql.pm
+++ b/lib/URI/mysql.pm
@@ -3,7 +3,7 @@ use base 'URI::_db';
 our $VERSION = '0.23';
 
 sub default_port { 3306 }
-sub dbi_driver   { 'mysql' }
+sub dbi_driver   { 'MariaDB' }
 sub canonical_engine { 'mysql' }
 
 sub _dbi_param_map {

--- a/t/dbi.t
+++ b/t/dbi.t
@@ -194,13 +194,13 @@ for my $spec (
     },
     {
         uri => 'db:mysql://localhost:33/foo',
-        dsn => 'dbi:mysql:host=localhost;port=33;database=foo',
+        dsn => 'dbi:MariaDB:host=localhost;port=33;database=foo',
         dbi => [ [host => 'localhost'], [port => 33], [database => 'foo'] ],
         qry => [],
     },
     {
         uri => 'db:mariadb://localhost:33/foo',
-        dsn => 'dbi:mysql:host=localhost;port=33;database=foo',
+        dsn => 'dbi:MariaDB:host=localhost;port=33;database=foo',
         dbi => [ [host => 'localhost'], [port => 33], [database => 'foo'] ],
         qry => [],
     },


### PR DESCRIPTION
It features better Unicode support and older versions of the MySQL client library, whereas DBD::mysql v5 requires the v8 MySQL library. So DBD::MariaDB is more compatible these days.

Discussion: https://www.perlmonks.org/?node_id=11163487